### PR TITLE
Python 3.12 support

### DIFF
--- a/src/passari/dpres/errors.py
+++ b/src/passari/dpres/errors.py
@@ -92,8 +92,7 @@ class JPEGMPONotSupportedError(ErrorDetector):
         stderr = exc.stderr.decode("utf-8")
 
         mpo_found = (
-            "Conflict with existing value 'image/jpeg' and new value "
-            "'image/mpo'"
+            "Conflict with values 'image/jpeg' and 'image/mpo' for 'mimetype'"
         ) in stderr
 
         if mpo_found:

--- a/src/passari/dpres/errors.py
+++ b/src/passari/dpres/errors.py
@@ -44,38 +44,6 @@ class JHOVEInvalidTIFFError(ErrorDetector):
             )
 
 
-class MultiPageTIFFError(ErrorDetector):
-    """
-    Raise a PreservationError if multi-page TIFF fails validation.
-    Multi-page TIFFs are not currently supported by the DPRES service.
-    """
-    def check(self, exc):
-        if exc.cmd[0] != "import-object":
-            return
-
-        file_path = exc.cmd[-1]
-        file_ext = file_path.split(".")[-1].lower()
-
-        if file_ext not in ("tif", "tiff"):
-            return
-
-        stderr = exc.stderr.decode("utf-8")
-
-        is_multipage = (
-            "The file contains multiple streams which is supported only for "
-            "video containers." in stderr
-        )
-
-        if is_multipage:
-            raise PreservationError(
-                detail=(
-                    f"TIFF file {exc.cmd[-1]} contains multiple pages and is "
-                    f"not currently allowed for preservation."
-                ),
-                error="Multi-page TIFF not allowed"
-            )
-
-
 class JPEGMIMETypeError(ErrorDetector):
     """
     Raise a PreservationError if MIME type for JPEG isn't detected correctly
@@ -175,7 +143,7 @@ class JPEGVersionNotSupportedError(ErrorDetector):
 
 
 ERROR_DETECTORS = (
-    JHOVEInvalidTIFFError, MultiPageTIFFError, JPEGMIMETypeError,
+    JHOVEInvalidTIFFError, JPEGMIMETypeError,
     JPEGMPONotSupportedError, JPEGVersionNotSupportedError
 )
 

--- a/tests/dpres/conftest.py
+++ b/tests/dpres/conftest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 
 
 @pytest.fixture(scope="function")
@@ -11,7 +12,7 @@ def package_dir(tmpdir):
     return package_dir
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 @pytest.mark.asyncio
 async def museum_package_factory(
         load_museum_object, mock_museumplus, package_dir):
@@ -25,7 +26,7 @@ async def museum_package_factory(
     return func
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 @pytest.mark.asyncio
 async def museum_package(museum_package_factory):
     return await museum_package_factory("1234567")

--- a/tests/dpres/test_errors.py
+++ b/tests/dpres/test_errors.py
@@ -65,21 +65,6 @@ async def test_generate_sip_invalid_tiff_jhove(
 
 
 @pytest.mark.asyncio
-async def test_generate_sip_multipage_tiff_not_allowed(
-        package_dir, museum_package_factory):
-    """
-    Test generating a SIP containing a multi-page TIFF which is not
-    allowed in the DPRES service
-    """
-    museum_package = await museum_package_factory("1234580")
-
-    with pytest.raises(PreservationError) as exc:
-        await museum_package.generate_sip()
-
-    assert "Multi-page TIFF not allowed" == exc.value.error
-
-
-@pytest.mark.asyncio
 async def test_generate_sip_jpeg_mime_type_not_detected(
         package_dir, museum_package_factory, monkeypatch):
     """

--- a/tests/museumplus/conftest.py
+++ b/tests/museumplus/conftest.py
@@ -8,6 +8,7 @@ from threading import Event, Thread
 import aiohttp
 import lxml.etree
 import pytest
+import pytest_asyncio
 
 
 @pytest.fixture(scope="function")
@@ -200,11 +201,10 @@ def mock_museumplus(launch_mock_museumplus):
     )
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def museum_session():
-    session = aiohttp.ClientSession()
-    yield session
-    await session.close()
+    async with aiohttp.ClientSession() as session:
+        yield session
 
 
 @pytest.fixture(scope="function")

--- a/tests/museumplus/data/museumplus_mock/module/README.md
+++ b/tests/museumplus/data/museumplus_mock/module/README.md
@@ -29,7 +29,7 @@ There are currently test files for the following fake objects:
 * Object 1234579
   * is linked to collection activities 765432001 and 765432002
 * Object 1234580
-  * has attachment 1234580001 (test.TIF) which will raise a PreservationError due to being a multi-page TIFF
+  * has attachment 1234580001 (test.TIF) which is a multi-page TIFF
 * Object 1234581
   * has attachment 1234581001 (test.JPG) which will raise a PreservationError due to being a MPO/JPEG image file
 * Object 1234582


### PR DESCRIPTION
Make changes to ensure the tests pass on Python 3.12 and the latest versions of dpres-siptools, pytest and pytest-asyncio.

Refs MPZ-4