### PR TITLE
Add dev requirements to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,10 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "ruff",
-    "ipython",
+    "pillow",
+    "pytest",
+    "pytest-asyncio",
+    "sftpserver",
 ]
 docs = ["sphinxcontrib-apidoc"]
 


### PR DESCRIPTION
List the development requirents as with package extra feature named "dev".  This allows installing them with `pip install .[dev]` or listing them in input file for pip-compile.