### PR TITLE
dpres/scripts: Log the current workdir of script executions

### DIFF
--- a/src/passari/dpres/scripts.py
+++ b/src/passari/dpres/scripts.py
@@ -61,6 +61,8 @@ async def run_command(
             await file_.write(
                 f"\n===COMMAND===\n{now.isoformat()}\n{cmd}".encode("utf-8")
             )
+            await file_.write(b"\n===CWD===\n")
+            await file_.write((cwd or os.getcwd()).encode("utf-8"))
             await file_.write(b"\n===STDOUT===\n")
             await file_.write(stdout)
             await file_.write(b"\n===STDERR===\n")


### PR DESCRIPTION
When running a dpres script its command, stdout and stderr is logged to a file.  Add also the current working directory (CWD) to that log to help debugging.