### PR TITLE
museumplus: Fetch 500 objects in bulk by default

### DIFF
--- a/src/passari/museumplus/search.py
+++ b/src/passari/museumplus/search.py
@@ -308,7 +308,7 @@ async def iterate_multimedia(
 
 
 async def iterate_objects(
-        session, offset: int = 0, limit: int = 50, modify_date_gte=None):
+        session, offset: int = 0, limit: int = 500, modify_date_gte=None):
     """
     Iterate all the Object modules in the MuseumPlus database starting from
     the given offset


### PR DESCRIPTION
When iterating objects with the iterate_objects function use 500 as the default limit, because it's much faster to fetch 500 objects in one go than fetching 50 objects 10 times.

This makes the sync commands (sync-objects etc.) much faster.