### PR TITLE
Update the passari version in METS premis agent metadata

### DIFF
--- a/src/passari/dpres/package.py
+++ b/src/passari/dpres/package.py
@@ -104,7 +104,7 @@ class MuseumObjectPackage:
         self.sip_agent_md = DigitalProvenanceAgentMetadata(
             name="passari",
             agent_type="software",
-            version="0.0.0"
+            version="1.2.0"
         )
 
     @classmethod


### PR DESCRIPTION
This makes it easier to compare the metadata generated by passari before and after the migration to dpres-siptools-ng.

Refs MPZ-19